### PR TITLE
Deinstallation hinzugefügt, Produktname in .ins gefixed

### DIFF
--- a/install.ins
+++ b/install.ins
@@ -3,7 +3,7 @@ Message=Installiere Only-Office...
 DefVar $ExitCode$
 
 [Actions]
-ShowBitmap "%ScriptPath%\logo.png" "Only-Office"
+ShowBitmap "%ScriptPath%\logo.png" "Freeoffice"
 Files_Copy
 WinBatch_Setup
 Sub_HandleExitCode

--- a/remove.ins
+++ b/remove.ins
@@ -1,14 +1,14 @@
 [Initial]
-Message=Deinstalliere Only-Office...
+Message=Deinstalliere Freeoffice...
 DefVar $ExitCode$
 
 [Actions]
-ShowBitmap "%ScriptPath%\logo.png" "Only-Office"
+ShowBitmap "%ScriptPath%\logo.png" "Freeoffice"
 WinBatch_Uninstall
 Sub_HandleExitCode
 
 [WinBatch_Uninstall]
-msiexec /passive /x "PATH"
+"%ScriptDrive%\tools\autoit\msiRemove_withLog.exe" "SoftMaker FreeOffice"
 
 [Sub_HandleExitCode]
 ; check return code


### PR DESCRIPTION
Da die remove.ins noch einen Platzhalter in der `WinBatch_Uninstall` Sektion enthielt, habe ich diese mit einem Aufruf von `msiRemove_withLog.exe` zur Deinstallation von FreeOffice ergänzt. Dazu war in sowohl der `install.ins` als auch der `remove.ins` als Produktanzeigename noch `Only-Office` hinterlegt, welche ich auch direkt auf FreeOffice geändert habe.